### PR TITLE
moved a free into if to avoid double free

### DIFF
--- a/simple_shell.c
+++ b/simple_shell.c
@@ -77,8 +77,8 @@ void find_cmd(paths *path, char *buffer)
 			perror("Command not found");
 		else
 			execute_command(arr);
+		free(arr[0]);
 	}
-	free(arr[0]);
 	free(arr);
 }
 


### PR DESCRIPTION
I retested and noticed an issue with double freeing when running exit after env has been run. I fixed the issue.